### PR TITLE
Execute brew Readall for supported OS/arch combinations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12]
+        os: [ubuntu-22.04, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew
@@ -17,7 +17,7 @@ jobs:
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
@@ -31,7 +31,15 @@ jobs:
 
       - run: brew test-bot --only-setup
 
-      - run: brew test-bot --only-tap-syntax
+      - name: Run brew readall for macOS (supports intel & arm arch)
+        if: runner.os == 'macOS'
+        run: |
+          brew readall --aliases --arch=intel ppc64le-cloud/pvsadm
+          brew readall --aliases --arch=arm ppc64le-cloud/pvsadm
+
+      - name: Run brew readall for Linux (supports intel)
+        if: runner.os == 'Linux'
+        run: brew readall --aliases --os=linux --arch=intel ppc64le-cloud/pvsadm
 
       - run: brew test-bot --only-formulae
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Replace `brew test-bot --only-tap-syntax` with brew readall commands for supported os and arch

Test run : https://github.com/carmal891/homebrew-pvsadm/actions/runs/13581845965/job/37969184416